### PR TITLE
Task-48208 : Errors during start about template config

### DIFF
--- a/services/src/main/java/org/exoplatform/mfa/notifications/provider/PushTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/mfa/notifications/provider/PushTemplateProvider.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @TemplateConfigs(templates = {
-    @TemplateConfig(pluginId = MfaAdminRevocationRequestPlugin.ID, template = "war:/notifications/templates/templates/push/MfaAdminRevocationRequestPlugin.gtmpl")
+    @TemplateConfig(pluginId = MfaAdminRevocationRequestPlugin.ID, template = "war:/notifications/templates/push/MfaAdminRevocationRequestPlugin.gtmpl")
 })
 public class PushTemplateProvider extends WebTemplateProvider {
 


### PR DESCRIPTION
Before this fix, there is an error at startup about loading template DocumentActivity.gtpml :

> WARN  | Failed to read template file: war:/notifications/templates/templates/push/MfaAdminRevocationRequestPlugin.gtmpl. An empty message will be used [o.e.c.n.template.TemplateUtils<Catalina-startStop-1>] 

This is due to the path in configuration file which is not correct : there are twice "templates"
This change update the path to use the correct one.