### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.commons-exo.version>6.5.x-SNAPSHOT</org.exoplatform.commons-exo.version>
 
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
@@ -37,9 +37,15 @@
     <dependencies>
       <!-- Import versions from platform project -->
       <dependency>
+<<<<<<< HEAD
         <groupId>org.exoplatform.social</groupId>
         <artifactId>social</artifactId>
         <version>${org.exoplatform.social.version}</version>
+=======
+        <groupId>org.exoplatform.commons-exo</groupId>
+        <artifactId>commons-exo</artifactId>
+        <version>${org.exoplatform.commons-exo.version}</version>
+>>>>>>> 8979a39 (Use new commons package for dependencies)
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>addons-parent-pom</artifactId>
+    <artifactId>addons-exo-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
     <version>17-exo-M01</version>
     <relativePath/>

--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,9 @@
     <dependencies>
       <!-- Import versions from platform project -->
       <dependency>
-<<<<<<< HEAD
-        <groupId>org.exoplatform.social</groupId>
-        <artifactId>social</artifactId>
-        <version>${org.exoplatform.social.version}</version>
-=======
         <groupId>org.exoplatform.commons-exo</groupId>
         <artifactId>commons-exo</artifactId>
         <version>${org.exoplatform.commons-exo.version}</version>
->>>>>>> 8979a39 (Use new commons package for dependencies)
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>addons-exo-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>17-exo-M01</version>
+    <version>17-M01</version>
     <relativePath/>
   </parent>
   <groupId>org.exoplatform.addons.multifactor-authentication</groupId>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds