### PR TITLE
fix: Display user's information in revocation requests list - EXO-64957

### DIFF
--- a/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/MultifactorAuthenticationComponent.vue
+++ b/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/MultifactorAuthenticationComponent.vue
@@ -139,10 +139,8 @@
                 <v-list-item-content class="flex-nowrap">
                   <div class="flex-shrink-1">
                     <exo-user-avatar
-                      :username="request.username"
-                      :fullname="request.fullname"
-                      :external="request.isExternal"
-                      :retrieve-extra-information="false" />
+                      :profile-id="request.username"
+                    />
                   </div>
                   <v-btn
                     v-exo-tooltip.bottom.body="$t('authentication.multifactor.revocation.action.accept')"


### PR DESCRIPTION
Before this change, no user's information was displayed in the revocation requests. This issue was due to the wrong properties passed as props to the ExoUserAvatar component, such as username, external, and retrieving extra information.

With this change, the profile-id will be passed as props to the ExoUserAvatar to display the user's information in the revocation request list