### PR TITLE
fix: move missing configuration file in mfa module - meeds-io/MIPs#79

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/conf/multifactor-authentication/mfa-notifications-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/multifactor-authentication/mfa-notifications-configuration.xml
@@ -5,7 +5,33 @@
                xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
 
-
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.api.notification.service.setting.PluginSettingService
+        </target-component>
+        <component-plugin profiles="all">
+            <name>notification.groups</name>
+            <set-method>registerGroupConfig</set-method>
+            <type>org.exoplatform.commons.api.notification.plugin.GroupProviderPlugin</type>
+            <description>Initial the default groups.</description>
+            <init-params>
+                <object-param>
+                    <name>group.security</name>
+                    <description>The information of group Security</description>
+                    <object type="org.exoplatform.commons.api.notification.plugin.config.GroupConfig">
+                        <field name="id">
+                            <string>security</string>
+                        </field>
+                        <field name="resourceBundleKey">
+                            <string>UINotification.label.group.Security</string>
+                        </field>
+                        <field name="order">
+                            <string>6</string>
+                        </field>
+                    </object>
+                </object-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
     <external-component-plugins>
         <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
         <component-plugin>


### PR DESCRIPTION
Before this fix, this mfa configuration was in social module. 
This commit moves the configuration in the correct mfa module.