### PR TITLE
fix: Multifactor admin : group suggestor ins't working - EXO-67960

### DIFF
--- a/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedGroupsUsersDrawer.vue
+++ b/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedGroupsUsersDrawer.vue
@@ -11,6 +11,7 @@
       <v-flex xs12 class="pa-3">
         <exo-identity-suggester
           v-model="groups"
+          item-text="spaceId"
           :ignore-items="ignoreItems"
           :labels="labels"
           :group-type="groupType"
@@ -87,12 +88,12 @@ export default {
                   id: `group:${group.groupName}`,
                   profile: {
                     avatarUrl: null,
-                    fullName: group.label,
-                    id: group.groupName
+                    fullName: group.id,
+                    id: group.groupName,
                   },
                   providerId: 'group',
                   remoteId: group.groupName,
-                  spaceId: null,                  
+                  spaceId: group.id,                  
                 });
               }
             }


### PR DESCRIPTION
Before this change, when open drawer de manage groups in Protected access to the platform, group suggestor isn't displayed and can't remove old saved groups. To resolve this problem, remplacer le exo-group-suggester par exo-identity-suggester. After this change, group suggestor is display spaces and is able to remove old saved groups in list.