### PR TITLE
fix: fix suggesting site in select protected Resource drawer - EXO-70336

### DIFF
--- a/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedResouceDrawer.vue
+++ b/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedResouceDrawer.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import {getNavigations, getProtectedNavigations} from '../multiFactorServices';
+import {getProtectedNavigations} from '../multiFactorServices';
 export default {
   data: () => ({
     drawer: false,
@@ -140,15 +140,15 @@ export default {
       }
     },
     getNavigations() {
-      getNavigations().then(data => {
+      return this.$siteService.getSites(null, 'USER', 'global').then(data => {
         const navs = data;
         navs.forEach(nav => {
-          nav.name = nav.key.name ;
-          if (nav.key.type === 'PORTAL') {
-            nav.id=`/portal/${nav.key.name}`;
-          } else if (nav.key.type === 'GROUP') {
-            const modifiedName = nav.key.name.replaceAll('/',':');
-            nav.id=`/portal/g/${modifiedName}`;
+          nav.label = nav.displayName ;
+          if (nav.siteType === 'PORTAL') {
+            nav.id =`/portal/${nav.name}`;
+          } else if (nav.siteType === 'GROUP') {
+            const modifiedName = nav.name.replaceAll('/',':');
+            nav.id =`/portal/g/${modifiedName}`;
           }
         });
         this.navigations = navs;


### PR DESCRIPTION
Before this change, when listing the navigations to selected to be protected not all navigations were listed since it uses an old API for navigation
After this change, all sites are listed  when using the new sites API