### PR TITLE
fix: fix suggesting site in select protected Resource drawer - EXO-70336

### DIFF
--- a/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedResouceDrawer.vue
+++ b/webapps/src/main/webapp/vue-apps/multi-factor-authentication/components/ProtectedResouceDrawer.vue
@@ -140,7 +140,7 @@ export default {
       }
     },
     getNavigations() {
-      return this.$siteService.getSites(null, 'USER', 'global').then(data => {
+      return this.$siteService.getSites(null, 'USER', 'global', true).then(data => {
         const navs = data;
         navs.forEach(nav => {
           nav.label = nav.displayName ;


### PR DESCRIPTION
Before this change, a log error  is displayed when retrieving sites because some group sites  have null navigation issues 
After this change, Empty navigation sites were excluded since we didn't need the site without navigations