### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/services/src/main/resources/db.changelogs/mfa-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/mfa-changelog-1.0.0.xml
@@ -29,6 +29,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <property name="now" value="CURRENT_TIMESTAMP" dbms="mssql" />
 
   <changeSet author="mfa" id="1.0.0-1" onValidationFail="MARK_RAN">
+    <validCheckSum>9:4650d39aea3f7b48c7b8f14e2f45e9db</validCheckSum>
     <preConditions onFail="MARK_RAN" onError="MARK_RAN">
       <not>
         <tableExists tableName="MFA_REVOCATION_REQUEST" />
@@ -45,7 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
@@ -56,5 +57,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <changeSet author="mfa" id="1.0.0-3" dbms="hsqldb">
     <createSequence sequenceName="SEQ_REVOCATION_REQUEST_ID" startValue="1"/>
   </changeSet>
-
+  <changeSet author="mfa" id="1.0.0-4" >
+    <sql dbms="mysql">
+      ALTER TABLE MFA_REVOCATION_REQUEST CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR.
This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564