### PR TITLE
fix: Fix Unit Test classes - MEED-7742 - Meeds-io/meeds#2537

### DIFF
--- a/services/src/test/java/org/exoplatform/mfa/api/storage/MfaStorageTest.java
+++ b/services/src/test/java/org/exoplatform/mfa/api/storage/MfaStorageTest.java
@@ -1,28 +1,25 @@
 package org.exoplatform.mfa.api.storage;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
 import org.exoplatform.commons.api.settings.ExoFeatureService;
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.mfa.storage.MfaStorage;
 import org.exoplatform.mfa.storage.dao.RevocationRequestDAO;
 import org.exoplatform.mfa.storage.dto.RevocationRequest;
 import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.branding.BrandingServiceImpl;
-import org.exoplatform.services.naming.InitialContextInitializer;
 import org.exoplatform.services.resources.ResourceBundleService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
-import static org.jgroups.util.Util.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 public class MfaStorageTest {
   private PortalContainer container;


### PR DESCRIPTION
Prior to this change, the `org.jgroups` package was used for Unit Tests assertions. This change uses `org.junit` package name instead to fix the useless dependency to jgroups.

Resolves https://github.com/Meeds-io/meeds/issues/2537