### PR TITLE
fix: preserve full initial URI (query params) during MFA redirection - EXO-82958

### DIFF
--- a/services/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
+++ b/services/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
@@ -1,6 +1,9 @@
 package org.exoplatform.mfa.filter;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,13 +53,20 @@ public class MfaFilter implements Filter {
         || mfaService.currentUserIsInProtectedGroup(ConversationState.getCurrent().getIdentity()))) {
       if (shouldAuthenticateFromSession(session) && excludedUrls.stream().noneMatch(requestUri::startsWith)) {
         LOG.debug("Mfa Filter must redirect on page to fill token");
-        httpServletResponse.sendRedirect(MFA_URI + "?initialUri=" + requestUri);
+        String queryString = httpServletRequest.getQueryString();
+        String fullUri = requestUri;
+        if (StringUtils.isNotBlank(queryString)) {
+            fullUri += "?" + queryString;
+        }
+        String encodedInitialUri = URLEncoder.encode(fullUri, StandardCharsets.UTF_8);
+        httpServletResponse.sendRedirect(MFA_URI + "?initialUri=" + encodedInitialUri);
         return;
       } else if (!shouldAuthenticateFromSession(session) && requestUri.startsWith(MFA_URI)) {
-        String queryString = httpServletRequest.getQueryString();
-        String initialUri = "/";
-        if (StringUtils.isNotBlank(queryString) && queryString.contains("initialUri=")) {
-          initialUri = queryString.substring(11);
+        String initialUri = httpServletRequest.getParameter("initialUri");
+        if (StringUtils.isBlank(initialUri)) {
+            initialUri = "/";
+        } else {
+            initialUri = URLDecoder.decode(initialUri, StandardCharsets.UTF_8);
         }
         httpServletResponse.sendRedirect(initialUri);
         return;


### PR DESCRIPTION
Prior to this change, the MFA filter was redirecting users using only the request path (getRequestURI), 
which caused query parameters to be lost during the MFA flow. This commit fixes the issue by:
- Reconstructing the full initial URI using both request URI and query string
- Properly URL-encoding the initialUri when redirecting to the MFA page
- Safely decoding the initialUri when redirecting back after MFA validation
- Using request parameters instead of fragile substring parsing