### PR TITLE
Fix: Notification for user's revoke request does not redirect to the Multifactor Authentication page - EXO-83412

### DIFF
--- a/services/src/main/java/org/exoplatform/mfa/notifications/utils/MfaNotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/mfa/notifications/utils/MfaNotificationUtils.java
@@ -23,7 +23,7 @@ public class MfaNotificationUtils {
         + "/"
         + portal
         + "/"
-        + "g/:platform:administrators/multifactor-authentication";
+        + "administration/home/security/multifactor-authentication";
   }
 
 


### PR DESCRIPTION
Before this change, when OTP protection was enabled on a page for external users, an issue occurred during the revoke request workflow. When an external user sent a revoke request and an administrator accessed the notification (either on-site or via email), they were redirected to a non-existent page due to an incorrect URL `/portal/g/:platform:administrators/multifactor-authentication`. To fix this issue, the incorrect URL was replaced with the valid one `/portal/administration/home/security/multifactor-authentication`. After this change, administrators are correctly redirected to the Multifactor Authentication page when accessing revoke request notifications.